### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/omniauth-trello.gemspec
+++ b/omniauth-trello.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{OAuth 1.0 Strategy for Trello}
   gem.summary       = %q{An OAuth 1.0 Strategy for Trello that abstracts the OAuth flow using the Omniauth gem}
   gem.homepage      = "https://github.com/joshrowley/omniauth-trello"
+  gem.license       = "MIT"
 
   gem.add_runtime_dependency      'omniauth', '~> 1.0'
   gem.add_runtime_dependency      'omniauth-oauth', '~> 1.0'


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.