### PR TITLE
Upgrade dependencies

### DIFF
--- a/lib/omniauth-trello/version.rb
+++ b/lib/omniauth-trello/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Trello
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end

--- a/omniauth-trello.gemspec
+++ b/omniauth-trello.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/joshrowley/omniauth-trello"
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency      'omniauth', '~> 1.0'
+  gem.add_runtime_dependency      'omniauth', '~> 2.0'
   gem.add_runtime_dependency      'omniauth-oauth', '~> 1.0'
-  gem.add_runtime_dependency      'oauth', '~> 0.4'
-  gem.add_dependency              'multi_json', '~>  1.5'
-  gem.add_development_dependency  'simplecov', '~> 0.7'
-  gem.add_development_dependency  'rspec', '~> 2.12'
+  gem.add_runtime_dependency      'oauth', '~> 0.5'
+  gem.add_dependency              'multi_json', '~> 1.15'
+  gem.add_development_dependency  'simplecov', '~> 0.21'
+  gem.add_development_dependency  'rspec', '~> 3.0'
   gem.add_development_dependency  'rack-test'
   gem.add_development_dependency  'webmock'
   gem.add_development_dependency  'rake'

--- a/spec/omniauth/strategies/trello_spec.rb
+++ b/spec/omniauth/strategies/trello_spec.rb
@@ -8,19 +8,19 @@ describe OmniAuth::Strategies::Trello do
 
   context "client options" do
     it "should have correct site" do
-      subject.options.client_options.site.should eq("https://trello.com")
+      expect(subject.options.client_options.site).to eq("https://trello.com")
     end
 
     it "should have correct authorize path" do
-      subject.options.client_options.authorize_path.should eq("/1/OAuthAuthorizeToken")
+      expect(subject.options.client_options.authorize_path).to eq("/1/OAuthAuthorizeToken")
     end
 
     it "should have the correct request token path" do
-      subject.options.client_options.request_token_path.should eq("/1/OAuthGetRequestToken")
+      expect(subject.options.client_options.request_token_path).to eq("/1/OAuthGetRequestToken")
     end
 
     it "should have the correct access token path" do
-      subject.options.client_options.access_token_path.should eq("/1/OAuthGetAccessToken")
+      expect(subject.options.client_options.access_token_path).to eq("/1/OAuthGetAccessToken")
     end
   end
 end


### PR DESCRIPTION
### Problem

While upgrading our app to [`omniauth` version 2.x](https://github.com/omniauth/omniauth/releases/tag/v2.0.0), we noticed version `0.0.4` was not compatible.


```
❯ bundle update omniauth-trello
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies.......
Bundler could not find compatible versions for gem "omniauth":
  In Gemfile:
    omniauth-rails_csrf_protection was resolved to 1.0.0, which depends on
      omniauth (~> 2.0)

    omniauth-trello (= 0.0.4) was resolved to 0.0.4, which depends on
      omniauth (~> 1.0)
```

### Solution
Upgrade dependencies!

`OmniAuth::Strategies::Trello` successful authorized our app with Trello.  No provider setup changes were required after bundling this branch.




